### PR TITLE
Fixed sentence offset errors

### DIFF
--- a/src/main/java/gov/nih/nlm/nls/metamap/lite/OpenNLPSentenceExtractor.java
+++ b/src/main/java/gov/nih/nlm/nls/metamap/lite/OpenNLPSentenceExtractor.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 
 import opennlp.tools.sentdetect.SentenceModel;
 import opennlp.tools.sentdetect.SentenceDetectorME;
+import opennlp.tools.util.Span;
 
 import gov.nih.nlm.nls.types.Sentence;
 import gov.nih.nlm.nls.types.Annotation;
@@ -112,11 +113,11 @@ public class OpenNLPSentenceExtractor implements SentenceExtractor
     logger.debug("createSentenceList");
     int sentenceCount = 0;
     int offset = 0;
-    String[] sentenceArray = sentenceDetector.sentDetect(text);
+    Span[] sentencePosArray = sentenceDetector.sentPosDetect(text);
     List<Sentence> sentenceList = new ArrayList<Sentence>();
-    for (String sentenceText: sentenceArray) {
-      sentenceList.add(new SentenceImpl("", sentenceText, offset));
-      offset = offset + sentenceText.length();
+    for (Span sentenceSpan: sentencePosArray) {
+      String sentenceText = sentenceSpan.getCoveredText(text).toString();
+      sentenceList.add(new SentenceImpl("", sentenceText, offset + sentenceSpan.getStart()));
       sentenceCount++;
     }
     return sentenceList;
@@ -125,11 +126,11 @@ public class OpenNLPSentenceExtractor implements SentenceExtractor
   public List<Sentence> createSentenceList(String text, int offset) {
     logger.debug("createSentenceList");
     int sentenceCount = 0;
-    String[] sentenceArray = sentenceDetector.sentDetect(text);
+    Span[] sentencePosArray = sentenceDetector.sentPosDetect(text);
     List<Sentence> sentenceList = new ArrayList<Sentence>();
-    for (String sentenceText: sentenceArray) {
-      sentenceList.add(new SentenceImpl("", sentenceText, offset));
-      offset = offset + sentenceText.length();
+    for (Span sentenceSpan: sentencePosArray) {
+      String sentenceText = sentenceSpan.getCoveredText(text).toString();
+      sentenceList.add(new SentenceImpl("", sentenceText, offset + sentenceSpan.getStart()));
       sentenceCount++;
     }
     return sentenceList;
@@ -150,12 +151,15 @@ public class OpenNLPSentenceExtractor implements SentenceExtractor
     logger.debug("createSentenceList");
     int sentenceCount = 0;
     int offset = passage.getOffset();
-    String[] sentenceArray = sentenceDetector.sentDetect(passage.getText());
-    for (String sentenceText: sentenceArray) {
+    String text = passage.getText();
+    Span[] sentencePosArray = sentenceDetector.sentPosDetect(passage.getText());
+    for (Span sentenceSpan: sentencePosArray) {
       // If sentence contains a semi-colon then split the sentence
       // into two utterances and add each to the passage, preserving
       // whitespace.
+      String sentenceText = sentenceSpan.getCoveredText(text).toString();
       int semicolonIndex = sentenceText.indexOf(";");
+      offset = sentenceSpan.getStart();
       if (semicolonIndex > 3) {
 	String[] utteranceArray = sentenceText.split(";");
 	for (String utteranceText: utteranceArray) {


### PR DESCRIPTION
The code currently assumes `sentDetect` splits text into contiguous segments. This is not guaranteed. In particular, it will skip over extra whitespace. For instance,

```
Sentence one. Sentence two.
Sentence three.  
Sentence four.  Sentence five.
```

The first three sentences are offset correctly. However, extra spaces at the end of the line after `three.`, and extra space after `four.` will not be included in the results of `sentDetect`, which results in offsets for sentences four and five to be incorrect. As a consequence, for example, since brat checks spans vs their contents, extra space in input files results in unusable (erroneous) `.ann` files.

Instead, I suggest using `sentPosDetect`, which returns exact spans where the sentences were found.