### PR TITLE
Removed an extraneous newline from brat .ann

### DIFF
--- a/src/main/java/gov/nih/nlm/nls/metamap/lite/resultformats/Brat.java
+++ b/src/main/java/gov/nih/nlm/nls/metamap/lite/resultformats/Brat.java
@@ -143,7 +143,7 @@ public class Brat implements ResultFormatter {
 
   public void entityListFormatter(PrintWriter writer,
 				  List<Entity> entityList) {
-    writer.println(annotationListToString(this.textLabel, entityList));
+    writer.print(annotationListToString(this.textLabel, entityList));
   }
 
   public String entityListFormatToString(List<Entity> entityList) {


### PR DESCRIPTION
brat annotation format is fiddly. If there is an empty line, brat will complain.

Each annotation is correctly terminated by a newline as the annotation string is being built. However, an extra newline is introduced by `println`. This causes an empty line, which in turn makes brat complain.

A switch to a simple `print` eliminates the empty line.