### PR TITLE
Restore Unicode-safe lookup behavior in dictionaryBinarySearch

### DIFF
--- a/src/main/java/irutils/MappedMultiKeyIndex.java
+++ b/src/main/java/irutils/MappedMultiKeyIndex.java
@@ -429,10 +429,10 @@ public class MappedMultiKeyIndex {
 	bsfp.get(tstwordbuf);
 	tstword = new String(tstwordbuf, charset);
 	// System.out.println("index: " + mid + ", address: " + (mid * (wordlen+datalen)) + ", tstword: " + tstword + ", word: " + word);
-	// cond = word.compareTo(tstword);
-	ByteBuffer wordByteBuf = ByteBuffer.wrap(word.getBytes(charset));
-	ByteBuffer tstwordByteBuf = ByteBuffer.wrap(tstwordbuf);
-	cond = wordByteBuf.compareTo(tstwordByteBuf);
+	 cond = word.compareTo(tstword);
+//	ByteBuffer wordByteBuf = ByteBuffer.wrap(word.getBytes(charset));
+//	ByteBuffer tstwordByteBuf = ByteBuffer.wrap(tstwordbuf);
+//	cond = wordByteBuf.compareTo(tstwordByteBuf);
 	if (cond < 0) {
 	  high = mid;
 	} else if (cond > 0) {


### PR DESCRIPTION
In comparison step of dictionaryBinarySearch(), I propose that we go back to doing string comparison (rather than byte-level comparison). This is necessary because the binary search table's layout on disk is being done according to Java's (Unicode-aware) string comparison order, not encoded byte comparison order, so the lookup needs to match. This fixes issue #1; see issue for more complete discussion.