### PR TITLE
Updating UIMA, mapdb, and jackson-dataformat-yaml to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.8.7</version>
+      <version>2.16.1</version>
     </dependency>
     <!-- https://metamap.nlm.nih.gov/maven2 -->
     <dependency>
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
-      <version>3.3.1</version>
+      <version>3.5.0</version>
     </dependency>
     
     <!-- 2019.0: https://mvnrepository.com/artifact/gov.nih.nlm.nls.lvg/lvgdist -->
@@ -222,7 +222,7 @@
     <dependency>
       <groupId>org.mapdb</groupId>
       <artifactId>mapdb</artifactId>
-      <version>3.0.7</version>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
These three libraries were a bit of date, and each had security-related fixes that seemed worth integrating.

As far as I can tell, this didn't break anything (`mvn test` is coming back clean). However, note that UIMA 3.5 requires Java 17, and I have a fuzzy recollection that MML is still stuck on Java 8. If that's the case, let's discuss!